### PR TITLE
block ai crawlers in robots.txt

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://fardog.io/"
 languageCode = "en-us"
 title = "fardog.io"
 theme = "cocoa"
+enableRobotsTXT = true
 
 [[menu.main]]
 name                   = "Projects"

--- a/config.toml
+++ b/config.toml
@@ -41,6 +41,8 @@ noshowreadtime         = false
 avatar                 = "img/profile.jpg"
 privacy_link           = "/privacy/"
 
+robotsBlockSourceUrl   = "https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/main/robots.txt"
+
 [markup]
   [markup.highlight]
   style = "monokailight"

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,4 +1,4 @@
-{{- $url := "https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/main/robots.txt" -}}
+{{- $url :=  .Site.Params.robotsBlockSourceUrl -}}
 {{- with resources.GetRemote $url -}}
   {{- with .Err -}}
     {{- errorf "%s" . -}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,12 @@
+{{- $url := "https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/main/robots.txt" -}}
+{{- with resources.GetRemote $url -}}
+  {{- with .Err -}}
+    {{- errorf "%s" . -}}
+  {{- else -}}
+    {{- .Content -}}
+  {{- end -}}
+{{- else -}}
+  {{- errorf "Unable to get remote resource %q" $url -}}
+{{- end }}
+User-agent: *
+Allow: /


### PR DESCRIPTION
Adds a `robots.txt` and blocks AI crawlers, using https://github.com/ai-robots-txt/ai.robots.txt as the source. This file is updated from the raw github URL on hugo build.